### PR TITLE
update available node sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,20 @@ module "k3s" {
 
 ## Variables
 
-|Name|Description|Default|
-|:---|---|:---:|
-|`applications`|Apps from Civo kubernetes marketplace|`Traefik, Metrics Server`|
-|`channel`|Channel to pull versions from. Possible values are development, stable and deprecated|`stable`|
-|`cluster_name`|Name for the cluster, if not set one is randomly generated|`""`|
-|`node_size`|Instance size for nodes. Possible values are `g2.xsmall`, `g2.small`, `g2.medium`, `g2.large`, `g2.xlarge` and `g2.2xlarge`|`g2.xsmall`|
-|`num_target_nodes`|Ammount of nodes to be created for this cluster|`1`|
-|`write_kubeconfig`|Write kubeconfig to file|`true`|
+| Name               | Description                                                                                                                                         |          Default          |
+| :----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | :-----------------------: |
+| `applications`     | Apps from Civo kubernetes marketplace                                                                                                               | `Traefik, Metrics Server` |
+| `channel`          | Channel to pull versions from. Possible values are development, stable and deprecated                                                               |         `stable`          |
+| `cluster_name`     | Name for the cluster, if not set one is randomly generated                                                                                          |           `""`            |
+| `node_size`        | Instance size for nodes. Possible values are `g3.k3s.xsmall`, `g3.k3s.small`, `g3.k3s.medium`, `g3.k3s.large`, `g3.k3s.xlarge` and `g3.k3s.2xlarge` |      `g3.k3s.xsmall`      |
+| `num_target_nodes` | Ammount of nodes to be created for this cluster                                                                                                     |            `1`            |
+| `write_kubeconfig` | Write kubeconfig to file                                                                                                                            |          `true`           |
 
 ## Outputs
-|Name|Description|
-|:---|---|
-|`cluster_ca_certificate`|Cluster ca certificate|
-|`host`|Endpoint for k3s api-server|
-|`password`|Cluster admin password|
-|`username`|Cluster admin username|
+
+| Name                     | Description                 |
+| :----------------------- | --------------------------- |
+| `cluster_ca_certificate` | Cluster ca certificate      |
+| `host`                   | Endpoint for k3s api-server |
+| `password`               | Cluster admin password      |
+| `username`               | Cluster admin username      |

--- a/var.tf
+++ b/var.tf
@@ -17,8 +17,8 @@ variable "cluster_name" {
 }
 
 variable "node_size" {
-  default     = "g2.xsmall"
-  description = "Instance size for nodes. Possible values are g2.xsmall, g2.small, g2.medium, g2.large, g2.xlarge and g2.2xlarge"
+  default     = "g3.k3s.xsmall"
+  description = "Instance size for nodes. Possible values are g3.k3s.xsmall, g3.k3s.small, g3.k3s.medium, g3.k3s.large, g3.k3s.xlarge and g3.k3s.2xlarge"
   type        = string
 }
 


### PR DESCRIPTION
Use the `g3.k3s` namespace instead of `g2`. Closes #1 .